### PR TITLE
api/add-name-to-topology-constraint-group

### DIFF
--- a/docs/api-reference/scheduler-api.md
+++ b/docs/api-reference/scheduler-api.md
@@ -159,6 +159,7 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
+| `name` _string_ | Name is the name of the topology constraint group.<br />It will drive from the corresponding PCSG name. |  |  |
 | `podGroupNames` _string array_ | PodGroupNames is the list of PodGroup names in the topology constraint group. |  |  |
 | `topologyConstraint` _[TopologyConstraint](#topologyconstraint)_ | TopologyConstraint defines topology packing constraints for this group.<br />Enables PCSG-level topology constraints.<br />Updated by operator when PodCliqueScalingGroup topology constraints change. |  |  |
 

--- a/docs/designs/topology.md
+++ b/docs/designs/topology.md
@@ -568,6 +568,9 @@ type PodGangSpec struct {
 ```go
 // TopologyConstraintGroupConfig defines topology constraints for a group of PodGroups.
 type TopologyConstraintGroupConfig struct {
+    // Name is the name of the topology constraint group.
+    // It will drive from the corresponding PCSG name.
+    Name string `json:"name"`   
     // TopologyConstraint defines topology packing constraints for this group.
     // Enables PCSG-level topology constraints.
     // Updated by operator when PodCliqueScalingGroup topology constraints change.

--- a/scheduler/api/core/v1alpha1/crds/scheduler.grove.io_podgangs.yaml
+++ b/scheduler/api/core/v1alpha1/crds/scheduler.grove.io_podgangs.yaml
@@ -167,6 +167,11 @@ spec:
                   description: TopologyConstraintGroupConfig defines topology constraints
                     for a group of PodGroups.
                   properties:
+                    name:
+                      description: |-
+                        Name is the name of the topology constraint group.
+                        It will drive from the corresponding PCSG name.
+                      type: string
                     podGroupNames:
                       description: PodGroupNames is the list of PodGroup names in
                         the topology constraint group.
@@ -200,6 +205,7 @@ spec:
                           type: object
                       type: object
                   required:
+                  - name
                   - podGroupNames
                   type: object
                 type: array

--- a/scheduler/api/core/v1alpha1/podgang.go
+++ b/scheduler/api/core/v1alpha1/podgang.go
@@ -115,6 +115,9 @@ type TopologyPackConstraint struct {
 
 // TopologyConstraintGroupConfig defines topology constraints for a group of PodGroups.
 type TopologyConstraintGroupConfig struct {
+	// Name is the name of the topology constraint group.
+	// It will drive from the corresponding PCSG name.
+	Name string `json:"name"`
 	// PodGroupNames is the list of PodGroup names in the topology constraint group.
 	PodGroupNames []string `json:"podGroupNames"`
 	// TopologyConstraint defines topology packing constraints for this group.


### PR DESCRIPTION
#### What type of PR is this?

/kind api
/kind feature

#### What this PR does / why we need it:

Adds a `name` field to `TopologyConstraintGroupConfig` in the scheduler API to make it easier to identify and manage topology constraint group configurations. The name is derived from the corresponding
PodCliqueScalingGroup (PCSG) name.

This change benefits:
- Easier identification when editing or adding topology constraint group configs
- Support for downstream schedulers (KAI) to reference and manage these configs by name

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

The `name` field is marked as required in the CRD. It will be automatically populated from the corresponding PCSG name by the operator.

#### Does this PR introduce a API change?

  ```release-note
  action required: TopologyConstraintGroupConfig now requires a `name` field. This field is automatically populated from the corresponding PodCliqueScalingGroup name.

  Additional documentation e.g., enhancement proposals, usage docs, etc.:

  - Updated scheduler API documentation to include the new `name` field
  - Updated topology design document with the field description
